### PR TITLE
feat: composition API上のコンポーネント名が取得できていなかった不具合修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,9 +3,9 @@ import { OccHeading } from "@/components/atoms/OccHeading";
 
 const components = [OccHeading];
 
-const install = function (Vue: App) {
+const install = function (Vue: App): void {
   components.forEach((component) => {
-    Vue.component((component as any).this.$options.name, component);
+    Vue.component(component.name, component);
   });
 };
 


### PR DESCRIPTION
対応内容
`(component as any).this.$options.name`  からコンポーネント名を取得できていなかったため修正